### PR TITLE
Correct artifact location in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ On Android, it's automatically handled by Gradle. It will also add `androidx.pag
 kotlin {
     ...
     sourceSets["commonMain"].dependencies {
-        api("io.github.kuuurt:multiplatform-paging:0.4.2")
+        api("io.github.kuuuurt:multiplatform-paging:0.4.2")
     }
 }
 ```


### PR DESCRIPTION
The `commonMain` artifact is incorrect in the readme file, meaning copy/pasting this line into a `build.gradle` file results in Gradle being unable to find the artifact.

This was changed before https://github.com/kuuuurt/multiplatform-paging/commit/10f0047cc34512face13ae2cd6bd1d9a69a3c214#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5, but it seems to have changed back in the meantime.