### PR TITLE
Fix issue with frozen pager on iOS

### DIFF
--- a/paging/src/iosMain/kotlin/com/kuuurt/paging/multiplatform/PagingData.kt
+++ b/paging/src/iosMain/kotlin/com/kuuurt/paging/multiplatform/PagingData.kt
@@ -7,22 +7,25 @@ package com.kuuurt.paging.multiplatform
  * @since 06/11/2020
  */
 
-actual class PagingData<T : Any> : MutableList<T> by mutableListOf()
+actual class PagingData<T : Any> internal constructor(items: List<T>) : List<T> by items
+
+internal fun <T: Any> List<T>.toPagingData(): PagingData<T> =
+    PagingData(this)
 
 actual suspend fun <T : Any> PagingData<T>.filter(predicate: suspend (T) -> Boolean): PagingData<T> {
-    return (this@filter as MutableList<T>).filter {
+    return (this@filter as List<T>).filter {
         predicate(it)
     } as PagingData<T>
 }
 
 actual suspend fun <T : Any, R : Any> PagingData<T>.map(transform: suspend (T) -> R): PagingData<R> {
-    return (this@map as MutableList<T>).map {
+    return (this@map as List<T>).map {
         transform(it)
     } as PagingData<R>
 }
 
 actual suspend fun <T : Any, R : Any> PagingData<T>.flatMap(transform: suspend (T) -> Iterable<R>): PagingData<R> {
-    return (this@flatMap as MutableList<T>).flatMap {
+    return (this@flatMap as List<T>).flatMap {
         transform(it)
     } as PagingData<R>
 }

--- a/paging/src/iosTest/kotlin/com.kuuurt.paging.multiplatform/PagerTests.kt
+++ b/paging/src/iosTest/kotlin/com.kuuurt.paging.multiplatform/PagerTests.kt
@@ -1,0 +1,39 @@
+package com.kuuurt.paging.multiplatform
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.first
+import kotlin.native.concurrent.freeze
+import kotlin.test.Test
+
+class PagerTests {
+
+    @Test
+    fun ensureFrozenPagerCanLoadData(): Unit = runBlocking {
+        val pageSize = 15
+        val pager = Pager(
+            CoroutineScope(Dispatchers.Default),
+            config = PagingConfig(
+                pageSize = pageSize,
+                enablePlaceholders = false,
+                initialLoadSize = pageSize,
+                prefetchDistance = pageSize,
+                maxSize = Int.MAX_VALUE,
+                jumpThreshold = Int.MIN_VALUE
+            ),
+            initialKey = 1,
+            getItems = { currentKey, size ->
+                val items = currentKey until (currentKey + size)
+                PagingResult(
+                    items = items.toList(),
+                    currentKey = currentKey,
+                    prevKey = { currentKey - pageSize - 1 },
+                    nextKey = { currentKey + pageSize + 1 }
+                )
+            }
+        )
+        pager.freeze()
+        pager.pagingData.first { it.size == pageSize }
+        pager.loadNext()
+        pager.pagingData.first { it.size == pageSize * 2 }
+    }
+}


### PR DESCRIPTION
Fixes #18.

Updated the pager to have a `StateFlow` containing the state of the pager.
Loading a new page will no longer modify the frozen pager but will emit a new state object instead.
The state objects are copied so they can be frozen as well.

Also added a test to verify the freezing is no longer an issue 😊. 