### PR TITLE
Implement `Pager.refresh` for JVM target

### DIFF
--- a/paging/src/commonMain/kotlin/com/kuuurt/paging/multiplatform/Pager.kt
+++ b/paging/src/commonMain/kotlin/com/kuuurt/paging/multiplatform/Pager.kt
@@ -21,4 +21,6 @@ expect class Pager<K: Any, V: Any>(
     getItems: suspend (K, Int) -> PagingResult<K, V>
 ) {
     val pagingData: Flow<PagingData<V>>
+
+    fun refresh()
 }

--- a/paging/src/iosMain/kotlin/com/kuuurt/paging/multiplatform/Pager.kt
+++ b/paging/src/iosMain/kotlin/com/kuuurt/paging/multiplatform/Pager.kt
@@ -35,7 +35,7 @@ actual class Pager<K : Any, V : Any> actual constructor(
         loadNext()
     }
 
-    fun refresh() {
+    actual fun refresh() {
         currentPagingResult.value = null
         _hasNextPage.value = false
         loadNext()

--- a/paging/src/jvmMain/kotlin/com/kuuurt/paging/multiplatform/Pager.kt
+++ b/paging/src/jvmMain/kotlin/com/kuuurt/paging/multiplatform/Pager.kt
@@ -22,15 +22,21 @@ actual class Pager<K : Any, V : Any> actual constructor(
     initialKey: K,
     getItems: suspend (K, Int) -> PagingResult<K, V>
 ) {
+    private var pagingSource: PagingSource<K, V>? = null
+
     actual val pagingData: Flow<PagingData<V>> = AndroidXPager(
         config = config,
         pagingSourceFactory = {
             PagingSource(
                 initialKey,
                 getItems
-            )
+            ).also { pagingSource = it }
         }
     ).flow
+
+    actual fun refresh() {
+        pagingSource?.invalidate()
+    }
 
     class PagingSource<K : Any, V : Any>(
         private val initialKey: K,


### PR DESCRIPTION
Fixes #22 

Builds upon https://github.com/kuuuurt/multiplatform-paging/commit/aed497443bd35ec451583db0395437ed2df4de4d to make the `refresh` API available on JVM as well.