### PR TITLE
Always create new PagingSource on Android.

### DIFF
--- a/paging/src/jvmMain/kotlin/com/kuuurt/paging/multiplatform/Pager.kt
+++ b/paging/src/jvmMain/kotlin/com/kuuurt/paging/multiplatform/Pager.kt
@@ -22,13 +22,16 @@ actual class Pager<K : Any, V : Any> actual constructor(
     initialKey: K,
     getItems: suspend (K, Int) -> PagingResult<K, V>
 ) {
-    private val source = PagingSource(
-        initialKey,
-        getItems
-    )
+    private var source: PagingSource<K, V>? = null
+
     actual val pagingData: Flow<PagingData<V>> = AndroidXPager(
         config = config,
-        pagingSourceFactory = { source }
+        pagingSourceFactory = {
+            PagingSource(
+                initialKey,
+                getItems
+            ).also { source = it }
+        }
     ).flow
 
     class PagingSource<K : Any, V : Any>(
@@ -69,6 +72,6 @@ actual class Pager<K : Any, V : Any> actual constructor(
     }
 
     actual fun refresh() {
-        source.invalidate()
+        source?.invalidate()
     }
 }


### PR DESCRIPTION
Always create new `PagingSource` on Android from `pagingSourceFactory`. This is required by Android Paging library. Fixes crash caused by common refresh logic changes in 0.6.0 version.

Crash description when refreshing pager with 0.6.0 version of library:

> An instance of PagingSource was re-used when Pager expected to create a newinstance. Ensure that the pagingSourceFactory passed to Pager always returns a new instance of PagingSource.